### PR TITLE
Update next branch to reflect new release-train "v10.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="10.2.0-next.0"></a>
+# 10.2.0-next.0 (2020-09-07)
+
+
+### Bug Fixes
+
+* **router:** ensure routerLinkActive updates when associated routerLinks change ([#38511](https://github.com/angular/angular/issues/38511)) ([dbfb50e](https://github.com/angular/angular/commit/dbfb50e)), closes [#18469](https://github.com/angular/angular/issues/18469)
+
+
+
 <a name="10.1.0-next.6"></a>
 # 10.1.0-next.6 (2020-08-17)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "10.2.0-next.0",
+  "version": "10.3.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v10.2.0-next.0 into the master branch so that the changelog is up to date.